### PR TITLE
Make pressing a file name open that file.

### DIFF
--- a/src/notes-tree.ts
+++ b/src/notes-tree.ts
@@ -36,6 +36,10 @@ const createNoteItem = (note: Note): NoteItem => {
     if (noteItem.id) {
         noteItem.command = new OpenNoteCommand(noteItem.id);
     }
+    if (details) {
+        // If details isn't undefined, set the command to the same as the parent
+        details[0].command = noteItem.command;
+    }
     noteItem.tooltip = note.text;
     noteItem.contextValue = getContextValue(note.status);
     noteItem.iconPath = getIconPath(note.status);


### PR DESCRIPTION
This PR causes clicking the file name of a note to navigate to the location of that note (by copying the command of the parent NoteItem). This fixes #10 .