### PR TITLE
add configurable TODO regex, fixes #20

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,18 +36,6 @@
         "title": "Code Annotation: Clear all notes"
       },
       {
-        "command": "code-annotation.addCustomTODO",
-        "title": "Code Annotation: Add custom TODO RegEx"
-      },
-      {
-        "command": "code-annotation.showCustomTODO",
-        "title": "Code Annotation: Show custom TODO RegEx's"
-      },
-      {
-        "command": "code-annotation.removeCustomTODO",
-        "title": "Code Annotation: Remove custom TODO RegEx"
-      },
-      {
         "command": "code-annotation.refreshEntry",
         "title": "Code Annotation: Refresh",
         "icon": {
@@ -216,6 +204,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show file name under annotation"
+        },
+        "customTODO": {
+          "type": "array",
+          "default": [],
+          "description": "An array of RegExps to use as TODO for note suggestions"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,18 @@
         "title": "Code Annotation: Clear all notes"
       },
       {
+        "command": "code-annotation.addCustomTODO",
+        "title": "Code Annotation: Add custom TODO RegEx"
+      },
+      {
+        "command": "code-annotation.showCustomTODO",
+        "title": "Code Annotation: Show custom TODO RegEx's"
+      },
+      {
+        "command": "code-annotation.removeCustomTODO",
+        "title": "Code Annotation: Remove custom TODO RegEx"
+      },
+      {
         "command": "code-annotation.refreshEntry",
         "title": "Code Annotation: Refresh",
         "icon": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,7 +17,7 @@ export const initializeStorageLocation = (location: string) => {
         }
         const extensionFilePath = getAnnotationFilePath();
         if (!fs.existsSync(extensionFilePath)) {
-            fs.writeFileSync(extensionFilePath, '{"notes":[], "nextId":1, "customTODO": []}');
+            fs.writeFileSync(extensionFilePath, '{"notes":[], "nextId":1}');
         }
     } else {
 	  	throw new Error('Error loading Storage for Extension');
@@ -26,13 +26,16 @@ export const initializeStorageLocation = (location: string) => {
 
 export interface Configuration {
     showFileName: boolean;
+    customTODO: string[]
 }
 
 export const getConfiguration = (): Configuration => {
     const configuration = vscode.workspace.getConfiguration();
     const showFileName = configuration.get('showFileName');
+    const customTODO: string[] = configuration.get('customTODO') || [];
     const config: Configuration = {
-        showFileName: typeof showFileName === 'boolean' ? showFileName : false
+        showFileName: typeof showFileName === 'boolean' ? showFileName : false,
+        customTODO: customTODO,
     };
 
     return config;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,7 +17,7 @@ export const initializeStorageLocation = (location: string) => {
         }
         const extensionFilePath = getAnnotationFilePath();
         if (!fs.existsSync(extensionFilePath)) {
-            fs.writeFileSync(extensionFilePath, '{"notes":[], "nextId":1}');
+            fs.writeFileSync(extensionFilePath, '{"notes":[], "nextId":1, "customTODO": []}');
         }
     } else {
 	  	throw new Error('Error loading Storage for Extension');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-import { addNote, addPlainNote } from './note-db';
+import { addNote, addPlainNote, addCustomTODO, showCustomTODO, removeCustomTODO } from './note-db';
 import { generateMarkdownReport } from './reporting';
 import { NotesTree, TreeActions } from './notes-tree';
 import { initializeStorageLocation, getAnnotationFilePath } from './configuration';
@@ -25,7 +25,19 @@ export function activate(context: vscode.ExtensionContext) {
         treeActions.openNoteFromId(id);
     });
 
-    vscode.commands.registerCommand('code-annotation.summary', () => {
+    vscode.commands.registerCommand('code-annotation.addCustomTODO', async () => {
+        addCustomTODO();
+    });
+
+    vscode.commands.registerCommand('code-annotation.showCustomTODO', async () => {
+        showCustomTODO();
+    });
+
+    vscode.commands.registerCommand('code-annotation.removeCustomTODO', async () => {
+        removeCustomTODO();
+    });
+
+    vscode.commands.registerCommand('code-annotation.summary', async () => {
         generateMarkdownReport();
     });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-import { addNote, addPlainNote, addCustomTODO, showCustomTODO, removeCustomTODO } from './note-db';
+import { addNote, addPlainNote} from './note-db';
 import { generateMarkdownReport } from './reporting';
 import { NotesTree, TreeActions } from './notes-tree';
 import { initializeStorageLocation, getAnnotationFilePath } from './configuration';
@@ -23,18 +23,6 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('code-annotation.copyNote', treeActions.copyNote.bind(treeActions));
     vscode.commands.registerCommand('code-annotation.openNoteFromId', (id: string) => {
         treeActions.openNoteFromId(id);
-    });
-
-    vscode.commands.registerCommand('code-annotation.addCustomTODO', async () => {
-        addCustomTODO();
-    });
-
-    vscode.commands.registerCommand('code-annotation.showCustomTODO', async () => {
-        showCustomTODO();
-    });
-
-    vscode.commands.registerCommand('code-annotation.removeCustomTODO', async () => {
-        removeCustomTODO();
     });
 
     vscode.commands.registerCommand('code-annotation.summary', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
         treeActions.openNoteFromId(id);
     });
 
-    vscode.commands.registerCommand('code-annotation.summary', async () => {
+    vscode.commands.registerCommand('code-annotation.summary', () => {
         generateMarkdownReport();
     });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-import { addNote, addPlainNote} from './note-db';
+import { addNote, addPlainNote } from './note-db';
 import { generateMarkdownReport } from './reporting';
 import { NotesTree, TreeActions } from './notes-tree';
 import { initializeStorageLocation, getAnnotationFilePath } from './configuration';

--- a/src/note-db.ts
+++ b/src/note-db.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getAnnotationFilePath } from './configuration';
+import { utils } from 'mocha';
 
 export interface Position {
     line: number;
@@ -22,12 +23,16 @@ export interface Note {
 export interface NotesDb {
     notes: Note[];
     nextId: number;
+    customTODO: string[];
 }
 
 export const getNotesDb = (): NotesDb => {
     const annotationFile = getAnnotationFilePath();
     const rawdata = fs.readFileSync(annotationFile, 'utf8');
     let annotations = JSON.parse(rawdata);
+    if (!annotations.customTODO) {
+        annotations.customTODO = [];
+    }
     return annotations;
 };
 
@@ -108,9 +113,23 @@ const addNoteToDb = (note: Note) => {
 const getTODOFromSelectedText = (): string | undefined => {
     const editor = vscode.window.activeTextEditor;
     const selectedText = editor?.selection ? editor.document.getText(editor.selection) : '';
-    const todoSelector = /\/\/ TODO: (.*)/;
+    const todoSelector = /\/\/\s*(TODO|FIX):\s*(.*)/;
     let matchArray = selectedText.match(todoSelector);
-    return matchArray?.length ? matchArray[1] : undefined;
+    if (matchArray && matchArray.length) {
+        return matchArray[2];
+    }
+    for (const custom of getNotesDb().customTODO) {
+        const customMatch = selectedText.match(custom);
+        if (customMatch && customMatch.length) {
+            // Use the second group to be consistent with the standard regex above
+            if (!customMatch[2]) {
+                vscode.window.showWarningMessage(`Custom TODO RegEx (${custom}) doesn't have atleast two capture groups`);
+            } else {
+                return customMatch[2];
+            }
+        }
+    }
+    return undefined;
 };
 
 export const addNote = async () => {
@@ -129,4 +148,48 @@ export const addPlainNote = async () => {
     if (annotationText) {
         addNoteToDb(createPlainNote(annotationText));
     }
+};
+
+export const addCustomTODO = async () => {
+    const annotationText = await vscode.window.showInputBox({ placeHolder: 'Enter a new regular expression for a custom TODO comment...'});
+    if (annotationText) {
+        let valid = true;
+        try {
+            new RegExp(annotationText);
+        } catch (e) {
+            valid = false;
+            await vscode.window.showErrorMessage(`Error interpreting input as a valid regular expression: ${e.toString()}`);
+        }
+        if (valid) {
+            // Its a valid RegEx, now check its not a duplicate
+            const config = getNotesDb();
+            if (config.customTODO.includes(annotationText)) {
+                await vscode.window.showErrorMessage('You\'ve already added this regular expression');
+            } else {
+                config.customTODO.push(annotationText);
+                saveDb(config);
+                await vscode.window.showInformationMessage(`Added the regular expression ${annotationText} successfully`);
+            }
+        }
+    }
+};
+
+export const removeCustomTODO = async () => {
+    const annotationText = await vscode.window.showInputBox({ placeHolder: 'Enter a regular expression to remove from your custom TODO comments'});
+    if (annotationText) {
+        // No need to check the validity of the RegEx here, simply check if it was already set
+        const customExisting = getNotesDb();
+        const index = customExisting.customTODO.indexOf(annotationText);
+        if (index > -1) {
+            customExisting.customTODO.splice(index, 1);
+            saveDb(customExisting);
+            await vscode.window.showInformationMessage(`Regular expression ${annotationText} removed successfuly`);
+        } else {
+            await vscode.window.showErrorMessage('There was no regular expression matching your entry saved');
+        }
+    }
+};
+
+export const showCustomTODO = async () => {
+    await vscode.window.showQuickPick(getNotesDb().customTODO || ['None set']);
 };

--- a/src/notes-tree.ts
+++ b/src/notes-tree.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { URI } from 'vscode-uri';
 
 import { getNotes, saveNotes, Note } from './note-db';
 import { getConfiguration } from './configuration';


### PR DESCRIPTION
This PR fixes #20 , allowing users to enter their own regex(es) for TODO style comments. Also adds a bit to the standard regex to achieve more coverage. 