### PR TITLE
Add category property to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@ Create and track annotations from your source code without actually committing c
 
 ### Attention
 
-This is still **work in progress**. You are welcome to test and give feedback on the extension, but we cannot guarantee compatibility with upcoming releases.
+This is still a **work in progress**. You are welcome to test and give feedback on the extension, but we cannot guarantee compatibility with upcoming releases.
 
 To test the extension download the [VSIX file](https://github.com/thamara/vscode-code-annotation/blob/master/code-annotation-0.0.1.vsix) and follow the steps on your VSCode:
 
 1. Go to the "Extensions" pane
 2. Click on the ... on the top right of the "Extensions" pane
 3. Select "Install from VSIX"
-4. Select the VSIX file you download and click install
+4. Select the VSIX file you downloaded and click install
 
 The "Code Annotation" can be found in the Activity pane.
 Feel free to open [issues](https://github.com/thamara/vscode-code-annotation/issues) and suggest [new features](https://github.com/thamara/vscode-code-annotation/projects/1) for the extension.
 
 ## Features
 
-- Create an annotation from the source code, selecting the portion of code, right-clicking and adding an annotation
+- Create an annotation from the source code, selecting the portion of code, right-clicking and adding a note
 - Keybinds for creating a new note from selection (`Ctrl/Cmd + alt + n)`, or without selection, aka Plain note (`Ctrl/Cmd + alt + p`)
 - Track annotations on its own pane
 - Check/Uncheck items as you complete them
-- Generate a report in Markdown with the pending and complete items
+- Generate a report in Markdown with a summary of the pending and completed items
 
 ## Development
 
@@ -35,7 +35,7 @@ Feel free to open [issues](https://github.com/thamara/vscode-code-annotation/iss
 npm install
 npm run compile
 ```
-- And to run/test the extension, go the the Run view and hit the green button on `Run Extension`. This will open a new VSCode window with the extension enabled.
+- And to run/test the extension, go the the Run pane and hit the green button on `Run Extension`. This will open a new VSCode window with the extension enabled.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -25,19 +25,23 @@
     "commands": [
       {
         "command": "code-annotation.addNote",
-        "title": "Code Annotation: Add note"
+        "category": "Code Annotation",
+        "title": "Add note"
       },
       {
         "command": "code-annotation.addPlainNote",
-        "title": "Code Annotation: Add plain note"
+        "category": "Code Annotation",
+        "title": "Add plain note"
       },
       {
         "command": "code-annotation.clearAllNotes",
-        "title": "Code Annotation: Clear all notes"
+        "category": "Code Annotation",
+        "title": "Clear all notes"
       },
       {
         "command": "code-annotation.refreshEntry",
-        "title": "Code Annotation: Refresh",
+        "category": "Code Annotation",
+        "title": "Refresh",
         "icon": {
           "light": "resources/light/refresh.svg",
           "dark": "resources/dark/refresh.svg"
@@ -45,7 +49,8 @@
       },
       {
         "command": "code-annotation.summary",
-        "title": "Code Annotation: Summary",
+        "category": "Code Annotation",
+        "title": "Summary",
         "icon": {
           "light": "resources/light/summary.svg",
           "dark": "resources/dark/summary.svg"
@@ -53,7 +58,8 @@
       },
       {
         "command": "code-annotation.removeNote",
-        "title": "Code Annotation: Remove",
+        "category": "Code Annotation",
+        "title": "Remove note",
         "icon": {
           "dark": "resources/dark/close.svg",
           "light": "resources/light/close.svg"
@@ -61,7 +67,8 @@
       },
       {
         "command": "code-annotation.checkNote",
-        "title": "Code Annotation: Check note",
+        "category": "Code Annotation",
+        "title": "Check note",
         "icon": {
           "dark": "resources/dark/check.svg",
           "light": "resources/light/check.svg"
@@ -69,7 +76,8 @@
       },
       {
         "command": "code-annotation.checkAllNotes",
-        "title": "Code Annotation: Check all notes",
+        "category": "Code Annotation",
+        "title": "Check all notes",
         "icon": {
           "dark": "resources/dark/checkall.svg",
           "light": "resources/light/checkall.svg"
@@ -77,7 +85,8 @@
       },
       {
         "command": "code-annotation.uncheckNote",
-        "title": "Code Annotation: Uncheck note",
+        "category": "Code Annotation",
+        "title": "Uncheck note",
         "icon": {
           "dark": "resources/dark/uncheck.svg",
           "light": "resources/light/uncheck.svg"
@@ -85,7 +94,8 @@
       },
       {
         "command": "code-annotation.uncheckAllNotes",
-        "title": "Code Annotation: Uncheck all notes",
+        "category": "Code Annotation",
+        "title": "Uncheck all notes",
         "icon": {
           "dark": "resources/dark/uncheckall.svg",
           "light": "resources/light/uncheckall.svg"
@@ -93,7 +103,8 @@
       },
       {
         "command": "code-annotation.removeAllNotes",
-        "title": "Code Annotation: Remove all notes",
+        "category": "Code Annotation",
+        "title": "Remove all notes",
         "icon": {
           "dark": "resources/dark/removeall.svg",
           "light": "resources/light/removeall.svg"
@@ -101,14 +112,17 @@
       },
       {
         "command": "code-annotation.openNote",
+        "category": "Code Annotation",
         "title": "Open note"
       },
       {
         "command": "code-annotation.editNote",
+        "category": "Code Annotation",
         "title": "Edit note"
       },
       {
         "command": "code-annotation.copyNote",
+        "category": "Code Annotation",
         "title": "Copy note"
       }
     ],
@@ -156,7 +170,7 @@
       "editor/context": [
         {
           "command": "code-annotation.addNote",
-          "title": "Code Annotation: Add note"
+          "title": "Add note"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
       "editor/context": [
         {
           "command": "code-annotation.addNote",
-          "title": "Add note"
+          "title": "Code Annotation: Add note"
         }
       ],
       "view/title": [


### PR DESCRIPTION
This PR adds a category property to the commands so 'Code Annotation' only prefix the command names in the **Command Palette** (Ctrl/Cmd+Shift+P), but not in the Code Annotation pane.

It also adds a few changes to the README that came up while I was getting familiar with the project. :)