### PR TITLE
Generate markdown reporting without saving

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -41,8 +41,8 @@ export const getConfiguration = (): Configuration => {
     const showFileName = configuration.get('showFileName');
     const customTODO: string[] = configuration.get('customTODO') || [];
     const enableDecoration : boolean = configuration.get('annotationBG.enableDecoration') || false;
-    const decorationDarkColor: string = configuration.get('annotationBG.color.dark') || "";
-    const decorationLightColor: string = configuration.get('annotationBG.color.light') || "";
+    const decorationDarkColor: string = configuration.get('annotationBG.color.dark') || '';
+    const decorationLightColor: string = configuration.get('annotationBG.color.light') || '';
     const config: Configuration = {
         showFileName: typeof showFileName === 'boolean' ? showFileName : false,
         customTODO: customTODO,

--- a/src/decoration/decoration.ts
+++ b/src/decoration/decoration.ts
@@ -11,11 +11,11 @@ const decorationType = () : vscode.TextEditorDecorationType => {
             backgroundColor: getConfiguration().decorationColors?.light
         }
     });
-}
+};
 
 export const setDecorations = (): void => {
     if (!getConfiguration().enableDecoration)
-        return;
+    { return; }
 
     const openEditors = vscode.window.visibleTextEditors;
 

--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -64,7 +64,7 @@ export const generateMarkdownReport = (): void => {
 
         return vscode.workspace.applyEdit(edit).then(success => {
             if (success) {
-                vscode.window.showTextDocument(summaryFile);
+                vscode.window.showTextDocument(summaryFile, /*column=*/undefined, /*preserveFocus=*/false);
             } else {
                 vscode.window.showInformationMessage('Error: Code Annotation could not generate a summary');
             }

--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -60,7 +60,9 @@ export const generateMarkdownReport = (): void => {
         const edit = new vscode.WorkspaceEdit();
         let notesSummary = getNotesInMarkdown();
 
-        edit.insert(newFile, new vscode.Position(0, 0), notesSummary);
+        const existingContentRange = new vscode.Range(new vscode.Position(0, 0),
+                                     new vscode.Position(summaryFile.lineCount + 1, 0));
+        edit.replace(newFile, existingContentRange, notesSummary);
 
         return vscode.workspace.applyEdit(edit).then(success => {
             if (success) {

--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
-import * as fs from 'fs';
 
 import { getNotes, Note } from './note-db';
 import { getRelativePathForFileName } from './utils';
@@ -56,18 +54,20 @@ export const getNotesInMarkdown = (): string => {
 };
 
 export const generateMarkdownReport = (): void => {
-    const workspaceFolder = vscode.workspace.rootPath;
-    // TODO: What if there's no workspace?
-    if (workspaceFolder) {
-        // TODO: Remove this hardcoded string, it should be a configuration
-        const extensionDirPath = path.join(workspaceFolder, '.vscode', 'code-annotation');
-        const extensionFilePath = path.join(extensionDirPath, 'summary.md');
-        let content = getNotesInMarkdown();
-        fs.writeFileSync(extensionFilePath, content);
-        var openPath = vscode.Uri.file(extensionFilePath);
-        vscode.workspace.openTextDocument(openPath).then(doc => {
-            vscode.window.showTextDocument(doc).then(editor => {
-            });
+    const newFile = vscode.Uri.parse('untitled:summary.md');
+
+    vscode.workspace.openTextDocument(newFile).then(summaryFile => {
+        const edit = new vscode.WorkspaceEdit();
+        let notesSummary = getNotesInMarkdown();
+
+        edit.insert(newFile, new vscode.Position(0, 0), notesSummary);
+
+        return vscode.workspace.applyEdit(edit).then(success => {
+            if (success) {
+                vscode.window.showTextDocument(summaryFile);
+            } else {
+                vscode.window.showInformationMessage('Error: Code Annotation could not generate a summary');
+            }
         });
-    }
+    });
 };


### PR DESCRIPTION
Closes #7 

This PR refactors `generateMarkdownReport` to create an unsaved markdown file independent of a workspace, giving user control of where/whether to saved it.

It also fixes some linting issues that were there for some reason. 😬 